### PR TITLE
plugin_geoip: allow datacenters to be omitted from auto_dc_coords

### DIFF
--- a/plugins/meta/libgdmaps/t/Makefile.am
+++ b/plugins/meta/libgdmaps/t/Makefile.am
@@ -41,7 +41,8 @@ TESTLIST = \
 	t10_def \
 	t11_def2 \
 	t12_defnone \
-	t13_castatdef
+	t13_castatdef \
+	t14_missingcoords
 
 check_PROGRAMS = $(TESTLIST:=.bin)
 

--- a/plugins/meta/libgdmaps/t/t14_missingcoords.c
+++ b/plugins/meta/libgdmaps/t/t14_missingcoords.c
@@ -1,0 +1,42 @@
+/* Copyright © 2012 Brandon L Black <blblack@gmail.com>
+ *
+ * This file is part of gdnsd-plugin-geoip.
+ *
+ * gdnsd-plugin-geoip is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * gdnsd-plugin-geoip is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with gdnsd.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+// Unit test for gdmaps
+
+#include "config.h"
+#include <gdnsd-log.h>
+#include "gdmaps_test.h"
+
+int main(int argc, char* argv[]) {
+    if(argc != 2)
+        log_fatal("root directory must be set on commandline");
+
+    gdmaps_t* gdmaps = gdmaps_test_init(argv[1]);
+    unsigned tnum = 0;
+    //datacenters => [ us, ie, sg, tr, br ]
+    gdmaps_test_lookup_check(tnum++, gdmaps, "my_prod_map", "137.138.144.168", "\2\1\5\3", 16); // Geneva
+    gdmaps_test_lookup_check(tnum++, gdmaps, "my_prod_map", "69.58.186.119", "\1\2\5\3", 16); // US East Coast
+    gdmaps_test_lookup_check(tnum++, gdmaps, "my_prod_map", "117.53.170.202", "\3\5\1\2", 20); // Australia
+    gdmaps_test_lookup_check(tnum++, gdmaps, "my_prod_map", "133.11.114.194", "\2\4", 8); // JP, horrible custom 'map' entry
+    gdmaps_test_lookup_check(tnum++, gdmaps, "my_prod_map", "10.0.0.44", "\4\2", 24); // Custom 'nets' entry
+    gdmaps_test_lookup_check(tnum++, gdmaps, "my_prod_map", "10.0.1.44", "", 24); // Custom 'nets' entry, empty
+    gdmaps_test_lookup_check(tnum++, gdmaps, "my_prod_map", "192.168.1.1", "\1\2\3\4\5", 16); // meta-default, no loc
+    gdmaps_destroy(gdmaps);
+}
+

--- a/plugins/meta/libgdmaps/t/t14_missingcoords.cfg
+++ b/plugins/meta/libgdmaps/t/t14_missingcoords.cfg
@@ -1,0 +1,29 @@
+options => { debug => true }
+plugins => {
+ geoip => {
+  maps => {
+   # bringing it all together: city-auto w/ 5 dcs,
+   #  dual GeoIP inputs, custom maps, custom nets
+   #  testing with one datacenter not used in auto coords
+   my_prod_map => {
+    geoip_db => GeoLiteCityv6-20111210.dat,
+    geoip_db_v4_overlay => GeoLiteCity-20111210.dat,
+    datacenters => [ us, ie, sg, tr, br ]
+    auto_dc_limit => 5,
+    auto_dc_coords => {
+     us = [ 38.9, -77 ]
+     ie = [ 53.3, -6.3 ]
+     sg = [ 1.3, 103.9 ]
+     br = [ -22.9, -43.2 ]
+    }
+    map => {
+     AS => { JP => [ ie, tr ] }
+    }
+    nets => {
+     10.0.1.0/24 => [ ]
+     10.0.0.0/24 => [ tr, ie ]
+    }
+   }
+  }
+ }
+}


### PR DESCRIPTION
Those datacenters will be never returned automatically. They are
available only from specific territories (map overrides) or subnets
(net overrides).

Signed-off-by: Timo Teräs timo.teras@iki.fi
