### PR TITLE
A couple sendmmsg() portability fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -68,8 +68,7 @@ AC_CHECK_MEMBERS([struct stat.st_mtimespec.tv_nsec])
 AC_CHECK_MEMBERS([struct stat.st_mtimensec])
 
 dnl *mmsg for Linux
-HAS_SENDMMSG=0
-AC_CHECK_FUNCS([sendmmsg],[HAS_SENDMMSG=1])
+AC_CHECK_FUNCS([recvmmsg sendmmsg])
 
 dnl ======== Begin Network Stuff ==========
 AC_DEFINE_UNQUOTED([__APPLE_USE_RFC_3542],1,[Force MacOS Lion to use RFC3542 IPv6 stuff])
@@ -376,7 +375,6 @@ dnl Summary output for the user
 
 if test "x$developer" != xno; then CFSUM_DEV=Yes; else CFSUM_DEV=No; fi
 if test "x$USE_LINUX_CAPS" = x1; then CFSUM_CAP=Yes; else CFSUM_CAP=No; fi
-if test "x$HAS_SENDMMSG" = x1; then CFSUM_SENDMMSG=Yes; else CFSUM_SENDMMSG=No; fi
 if test "x$USE_INOTIFY" = x1; then CFSUM_INOTIFY=Yes; else CFSUM_INOTIFY=No; fi
 if test "x$HAVE_QSBR" = x1; then
     CFSUM_QSBR=Yes
@@ -394,7 +392,6 @@ echo "| Configuration Summary:"
 echo "| Developer Build?        $CFSUM_DEV"
 echo "| Userspace-rcu support:  $CFSUM_QSBR"
 echo "| Linux libcap support:   $CFSUM_CAP"
-echo "| Linux sendmmsg support: $CFSUM_SENDMMSG"
 echo "| Linux inotify support:  $CFSUM_INOTIFY"
 echo "| Test Port Start:        $CFSUM_TP"
 echo "======================================="

--- a/gdnsd/dnsio_udp.c
+++ b/gdnsd/dnsio_udp.c
@@ -35,6 +35,7 @@
 #include "conf.h"
 #include "dnswire.h"
 #include "dnspacket.h"
+#include "sendmmsg-compat.h"
 #include "gdnsd/log.h"
 #include "gdnsd/prcu-priv.h"
 
@@ -284,7 +285,7 @@ static void mainloop(const int fd, dnspacket_context_t* pctx, const bool use_cms
     }
 }
 
-#ifdef HAVE_SENDMMSG
+#ifdef USE_MMSG
 
 // check for linux 3.0+ for sendmmsg() (implies recvmmsg w/ MSG_WAITFORONE)
 static bool has_mmsg(void) {
@@ -392,11 +393,11 @@ static void mainloop_mmsg(const unsigned width, const int fd, dnspacket_context_
     }
 }
 
-#else // HAVE_SENDMMSG
+#else // USE_MMSG
 
 static bool has_mmsg(void) { return false; }
 
-#endif // HAVE_SENDMMSG
+#endif // USE_MMSG
 
 // We need to use cmsg stuff in the case of any IPv6 address (at minimum,
 //  to copy the flow label correctly, if not the interface + source addr),
@@ -441,7 +442,7 @@ void* dnsio_udp_start(void* addrconf_asvoid) {
     gdnsd_prcu_rdr_thread_start();
     pthread_cleanup_push(thread_clean, NULL);
 
-#ifdef HAVE_SENDMMSG
+#ifdef USE_MMSG
     if(addrconf->udp_recv_width > 1) {
         log_debug("sendmmsg() with a width of %u enabled for UDP socket %s",
             addrconf->udp_recv_width, logf_anysin(&addrconf->addr));

--- a/gdnsd/sendmmsg-compat.h
+++ b/gdnsd/sendmmsg-compat.h
@@ -1,0 +1,61 @@
+/* Copyright © 2013 Faidon Liambotis <paravoid@debian.org>
+ *
+ * This file is part of gdnsd.
+ *
+ * gdnsd is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * gdnsd is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with gdnsd.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef GDNSD_SENDMMSG_H
+#define GDNSD_SENDMMSG_H
+
+#include <sys/socket.h>
+#include <unistd.h>
+#include <sys/syscall.h>
+#include "config.h"
+
+#if (defined(HAVE_RECVMMSG) || defined(SYS_recvmmsg) || defined(__NR_recvmmsg)) && \
+    (defined(HAVE_SENDMMSG) || defined(SYS_sendmmsg) || defined(__NR_sendmmsg))
+#define USE_MMSG 1
+
+#ifndef MSG_WAITFORONE
+#define MSG_WAITFORONE 0x10000
+#endif // MSG_WAITFORONE
+
+#ifndef HAVE_RECVMMSG
+static int recvmmsg(int sockfd, struct mmsghdr *msgvec, unsigned int vlen,
+                    unsigned int flags, struct timespec *timeout) {
+#if defined(SYS_recvmmsg)
+        return syscall(SYS_recvmmsg, sockfd, msgvec, vlen, flags, timeout);
+#elif defined(__NR_recvmmsg)
+        return syscall(__NR_recvmmsg, sockfd, msgvec, vlen, flags, timeout);
+#endif
+}
+#endif // HAVE_RECVMMSG
+
+#ifndef HAVE_SENDMMSG
+static int sendmmsg(int sockfd, struct mmsghdr *msgvec, unsigned int vlen, unsigned int flags) {
+#if defined(SYS_sendmmsg)
+        return syscall(SYS_sendmmsg, sockfd, msgvec, vlen, flags);
+#elif defined(__NR_sendmmsg)
+        return syscall(__NR_sendmmsg, sockfd, msgvec, vlen, flags);
+#endif
+}
+#endif // HAVE_SENDMMSG
+
+#else
+#undef USE_MMSG
+#endif
+
+#endif // GDNSD_SENDMMSG_H


### PR DESCRIPTION
The first one makes fixes sendmmsg() runtime detection as to make it available to RHEL 6.2 and possibly others. It's untested on that platform, but worked on tests of mine on both 2.6.32 (negative) & 3.2.0 (positive).

The second one I expect to be a little more controversial. The goal is to make the sendmmsg() functionality available in certain systems (_cough_ Debian wheezy) but in the expense of ugly preprocessor clutter & hacks.
