### PR TITLE
Segfault while reading GeoIPv6.dat

### DIFF
--- a/plugins/meta/libgdmaps/t/gdmaps_test.c
+++ b/plugins/meta/libgdmaps/t/gdmaps_test.c
@@ -45,16 +45,25 @@
 #include "gdmaps.h"
 #include "gdmaps_test.h"
 
-static const char CFG_PATH[] = "etc/config";
+static const vscf_data_t* conf_load_vscf(void) {
+    const vscf_data_t* out = NULL;
 
-static const vscf_data_t* conf_load(void) {
-    char* vscf_err;
-    const vscf_data_t* cfg_root = vscf_scan_filename(CFG_PATH, &vscf_err);
-    if(!cfg_root)
-        log_fatal("Configuration load from %s failed: %s", logf_pathname(CFG_PATH), vscf_err);
+    char* cfg_path = gdnsd_resolve_path_cfg("config", NULL);
 
-    dmn_assert(vscf_is_hash(cfg_root));
-    return cfg_root;
+    struct stat cfg_stat;
+    if(!stat(cfg_path, &cfg_stat)) {
+        log_debug("Loading configuration from '%s'", cfg_path);
+        char* vscf_err;
+        out = vscf_scan_filename(cfg_path, &vscf_err);
+        if(!out)
+            log_fatal("Configuration from '%s' failed: %s", cfg_path, vscf_err);
+    }
+    else {
+        log_debug("No config file at '%s', using defaults + zones auto-scan", cfg_path);
+    }
+
+    free(cfg_path);
+    return out;
 }
 
 F_NONNULL
@@ -149,7 +158,7 @@ gdmaps_t* gdmaps_test_init(const char* input_rootdir) {
     dmn_init_log("gdmaps_test", true);
 
     gdnsd_set_rootdir(input_rootdir);
-    const vscf_data_t* cfg_root = conf_load();
+    const vscf_data_t* cfg_root = conf_load_vscf();
     conf_options(cfg_root);
 
     const vscf_data_t* maps_cfg = conf_get_maps(cfg_root);


### PR DESCRIPTION
I'm trying gdnsd 1.7.5 with a geoip configuration.

As soon as I switch geoip_db => /usr/share/GeoIP/GeoIP.dat to geoip_db => /usr/share/GeoIP/GeoIPv6.dat, I get a segfault:

```
# gdnsd checkconf
Loading configuration
[...]
plugin_geoip: map 'my_prod_map': Processing GeoIP database '/usr/share/GeoIP/GeoIPv6.dat'
Segmentation fault
```

If I try with geoip_db => /usr/share/GeoIP/GeoIPv6.dat,             geoip_db_v4_overlay => /usr/share/GeoIP/GeoIP.dat I get instead:

```
plugin_geoip: map 'my_prod_map': Processing GeoIP database '/usr/share/GeoIP/GeoIPv6.dat'
plugin_geoip: map 'my_prod_map': Primary GeoIP DB '/usr/share/GeoIP/GeoIPv6.dat' is not an IPv6 database and this map uses geoip_v4_overlay
plugin_geoip: map 'my_prod_map': (Re-)loading geoip database '/usr/share/GeoIP/GeoIPv6.dat' failed!
plugin_geoip: map 'my_prod_map': cannot continue initial load
```

Unfortunately gdb doesn't help much here, not sure why:

```
Program received signal SIGSEGV, Segmentation fault.
0x0000000000000000 in ?? ()
(gdb) bt
#0  0x0000000000000000 in ?? ()
#1  0x0000000000000000 in ?? ()
```

I built a developer build which instead prints:
17:44:14 gdnsd [26639] fatal: Assertion 'depth > 0' failed in list_xlate_recurse() at gdgeoip.c:413

Running under gdb that and breaking on list_xlate_recurse() reveals a call with depth=32, then a call with depth=31, then depth=30 and so on, until one with deph=0, where it finally aborts.

The files came from Debian's
http://packages.debian.org/sid/all/geoip-database/download
which in turn are MaxMind's 2013-01-08 databases.
