### PR TITLE
Segfault while reading GeoIPv6.dat

### DIFF
--- a/plugins/meta/libgdmaps/gdgeoip.c
+++ b/plugins/meta/libgdmaps/gdgeoip.c
@@ -542,7 +542,7 @@ static geoip_db_t* geoip_db_open(const char* pathname, const char* map_name, dcl
      *   3 bytes of the file.  If that's 0xFFFFFF, we're done,
      *   and it's a plain country database.
      * If those 3 bytes aren't 0xFFFFFF, then we step back by
-     *   *four* bytes and try again.  From here on when we get
+     *   one byte and try again.  From here on when we get
      *   our match on the first 3 bytes being 0xFFFFFF, the
      *   4th byte is the database type.
      */
@@ -553,7 +553,7 @@ static geoip_db_t* geoip_db_open(const char* pathname, const char* map_name, dcl
             if(i) db->type = db->data[offset + 3];
             break;
         }
-        offset -= 4;
+        offset -= 1;
         if(offset < 0)
             break;
     }


### PR DESCRIPTION
(filing #24 again, as I messed that one up and GitHub is unforgiving)

I'm trying gdnsd 1.7.5 with a geoip configuration.

As soon as I switch geoip_db => /usr/share/GeoIP/GeoIP.dat to geoip_db => /usr/share/GeoIP/GeoIPv6.dat, I get a segfault:

```
# gdnsd checkconf
Loading configuration
[...]
plugin_geoip: map 'my_prod_map': Processing GeoIP database '/usr/share/GeoIP/GeoIPv6.dat'
Segmentation fault
```

If I try with geoip_db => /usr/share/GeoIP/GeoIPv6.dat,             geoip_db_v4_overlay => /usr/share/GeoIP/GeoIP.dat I get instead:

```
plugin_geoip: map 'my_prod_map': Processing GeoIP database '/usr/share/GeoIP/GeoIPv6.dat'
plugin_geoip: map 'my_prod_map': Primary GeoIP DB '/usr/share/GeoIP/GeoIPv6.dat' is not an IPv6 database and this map uses geoip_v4_overlay
plugin_geoip: map 'my_prod_map': (Re-)loading geoip database '/usr/share/GeoIP/GeoIPv6.dat' failed!
plugin_geoip: map 'my_prod_map': cannot continue initial load
```

Unfortunately gdb doesn't help much here, not sure why:

```
Program received signal SIGSEGV, Segmentation fault.
0x0000000000000000 in ?? ()
(gdb) bt
#0  0x0000000000000000 in ?? ()
#1  0x0000000000000000 in ?? ()
```

I built a developer build which instead prints:
17:44:14 gdnsd [26639] fatal: Assertion 'depth > 0' failed in list_xlate_recurse() at gdgeoip.c:413

Running under gdb that and breaking on list_xlate_recurse() reveals a call with depth=32, then a call with depth=31, then depth=30 and so on, until one with deph=0, where it finally aborts.

The files came from Debian's
http://packages.debian.org/sid/all/geoip-database/download
which in turn are MaxMind's 2013-01-08 databases.

Note that this was caught by a manual test and not by the test suite in my case.

While it is not possible in the Debian autobuilder network to fetch GeoLite from the network (for determinism, security and licensing reasons), it would be possible to fetch the "regular" GeoIP database package and run the relevant parts of the test suite against them, if the test suite supported such an alternative mode of operations.
