### PR TITLE
Fix Linux version detection for initial 3.x kernels

### DIFF
--- a/gdnsd/libgdnsd/misc.c
+++ b/gdnsd/libgdnsd/misc.c
@@ -212,13 +212,19 @@ bool gdnsd_linux_min_version(const unsigned x, const unsigned y, const unsigned 
     bool rv = false;
     struct utsname uts;
     if(!uname(&uts) && !strcmp("Linux", uts.sysname)) {
+        const uint32_t vers_wanted = _version_fold(x, y, z);
+        uint32_t vers_have = _version_fold(0, 0, 0);
+
         unsigned sys_x, sys_y, sys_z;
         if(sscanf(uts.release, "%u.%u.%u", &sys_x, &sys_y, &sys_z) == 3) {
-            const uint32_t vers_have = _version_fold(sys_x, sys_y, sys_z);
-            const uint32_t vers_wanted = _version_fold(x, y, z);
-            if(vers_have >= vers_wanted)
-                rv = true;
+            vers_have = _version_fold(sys_x, sys_y, sys_z);
+        } else if(sscanf(uts.release, "%u.%u", &sys_x, &sys_y) == 2) {
+            /* no patch version number, e.g. 3.2 */
+            vers_have = _version_fold(sys_x, sys_y, 0);
         }
+
+        if(vers_have >= vers_wanted)
+            rv = true;
     }
     return rv;
 }


### PR DESCRIPTION
Upstream Linux's version numbering changed with 3.0: the "2.6" prefix
was replaced with just "3" and hence initial versions of kernels have
only two components, major & minor (e.g. 3.2). Subsequent stable release
updates have three parts, which is equivalent to the four parts that 2.6
stable updates had.

gdnsd_linux_min_version() assumes that three components _must_ exist and
hence is broken with the initial versions of all 3.x kernels. Fix this
in a backwards- and forwards-compatible manner by assuming z=0 for
kernels that do not match x.y.z but match x.y.
