### PR TITLE
Only use EPROTO if it's available.

### DIFF
--- a/gdnsd/dnsio_tcp.c
+++ b/gdnsd/dnsio_tcp.c
@@ -247,8 +247,10 @@ static void accept_handler(struct ev_loop* loop, ev_io* io, const int revents V_
             case ENONET:
 #endif
             case ENETDOWN:
-            case EPROTO:
-            case EHOSTDOWN:
+#ifdef EPROTO
+	    case EPROTO:
+#endif
+	    case EHOSTDOWN:
             case EHOSTUNREACH:
             case ENETUNREACH:
                 log_devdebug("TCP DNS: early tcp socket death: %s", dmn_logf_errno());

--- a/gdnsd/statio.c
+++ b/gdnsd/statio.c
@@ -525,8 +525,10 @@ static void accept_cb(struct ev_loop* loop, ev_io* io, int revents V_UNUSED) {
             case ENONET:
 #endif
             case ENETDOWN:
-            case EPROTO:
-            case EHOSTDOWN:
+#ifdef EPROTO
+	    case EPROTO:
+#endif
+	    case EHOSTDOWN:
             case EHOSTUNREACH:
             case ENETUNREACH:
                 log_debug("HTTP: early tcp socket death: %s", dmn_logf_errno());


### PR DESCRIPTION
This unbreaks the build on OpenBSD which lacks EPROTO.
