### PR TITLE
Add a max_proc argument to extmon

### DIFF
--- a/docs/gdnsd-plugin-extmon.podin
+++ b/docs/gdnsd-plugin-extmon.podin
@@ -22,6 +22,7 @@ Example plugin config:
     svc_alwaysfail_via_timeout => {
       plugin => "extmon",
       timeout => 2,
+      max_proc => 10,
       cmd => ["/bin/sh", "-c", "sleep 5"]
     }
   }
@@ -122,6 +123,17 @@ and failure on every run, so will the internal state and so will the resulting
 changes in resolution.  Useful if extmon is actually gathering state from an
 external complex monitoring environment that has already taken care of things
 like anti-flap measures.
+
+=item B<max_proc>
+
+Interger, default 0 (unlimited).
+
+The maximum number of concurrent processes to spawn.
+
+This sets the limit on the number of concurrent commands that will be run.
+If the limit is exceeded, excess commands are rescheduled for 0.1 seconds
+later. After a few runs, the processes will be spread out enough to run
+without running into the limit.
 
 =back
 

--- a/plugins/extmon.c
+++ b/plugins/extmon.c
@@ -372,9 +372,9 @@ void plugin_extmon_load_config(vscf_data_t* config, const unsigned num_threads V
             unsigned long _val; \
             if(!vscf_is_simple(_data) \
             || !vscf_simple_get_as_ulong(_data, &_val)) \
-                log_fatal("plugin_http_status: Service type '%s': option '%s': Value must be a positive integer", _typnam, #_loc); \
+                log_fatal("plugin_extmon: Service type '%s': option '%s': Value must be a positive integer", _typnam, #_loc); \
             if(_val < _min || _val > _max) \
-                log_fatal("plugin_http_status: Service type '%s': option '%s': Value out of range (%lu, %lu)", _typnam, #_loc, _min, _max); \
+                log_fatal("plugin_extmon: Service type '%s': option '%s': Value out of range (%lu, %lu)", _typnam, #_loc, _min, _max); \
             _loc = (unsigned) _val; \
         } \
     } while(0)
@@ -383,7 +383,7 @@ void plugin_extmon_add_svctype(const char* name, vscf_data_t* svc_cfg, const uns
     dmn_assert(name); dmn_assert(svc_cfg);
 
     // defaults
-    unsigned max_proc = 80;
+    unsigned max_proc = 0;
 
 
     svcs = xrealloc(svcs, (num_svcs + 1) * sizeof(svc_t));
@@ -391,7 +391,7 @@ void plugin_extmon_add_svctype(const char* name, vscf_data_t* svc_cfg, const uns
     this_svc->name = strdup(name);
     this_svc->timeout = timeout;
     this_svc->interval = interval;
-    SVC_OPT_UINT(svc_cfg, name, max_proc, 1LU, 65534LU);
+    SVC_OPT_UINT(svc_cfg, name, max_proc, 0LU, 65534LU);
     this_svc->max_proc = max_proc;
 
     vscf_data_t* args_cfg = vscf_hash_get_data_byconstkey(svc_cfg, "cmd", true);

--- a/plugins/extmon.c
+++ b/plugins/extmon.c
@@ -46,6 +46,7 @@ typedef struct {
     unsigned num_args;
     unsigned timeout;
     unsigned interval;
+    unsigned max_proc;
     bool direct;
 } svc_t;
 
@@ -228,6 +229,7 @@ static void send_cmd(const unsigned idx, const mon_t* mon) {
         .idx = idx,
         .timeout = mon->svc->timeout,
         .interval = mon->svc->interval,
+        .max_proc = mon->svc->max_proc,
         .num_args = mon->svc->num_args,
         .args = this_args,
         .desc = mon->desc,
@@ -363,14 +365,34 @@ void plugin_extmon_load_config(vscf_data_t* config, const unsigned num_threads V
         helper_path = gdnsd_resolve_path_libexec("gdnsd_extmon_helper", NULL);
 }
 
+#define SVC_OPT_UINT(_hash, _typnam, _loc, _min, _max) \
+    do { \
+        vscf_data_t* _data = vscf_hash_get_data_byconstkey(_hash, #_loc, true); \
+        if(_data) { \
+            unsigned long _val; \
+            if(!vscf_is_simple(_data) \
+            || !vscf_simple_get_as_ulong(_data, &_val)) \
+                log_fatal("plugin_http_status: Service type '%s': option '%s': Value must be a positive integer", _typnam, #_loc); \
+            if(_val < _min || _val > _max) \
+                log_fatal("plugin_http_status: Service type '%s': option '%s': Value out of range (%lu, %lu)", _typnam, #_loc, _min, _max); \
+            _loc = (unsigned) _val; \
+        } \
+    } while(0)
+
 void plugin_extmon_add_svctype(const char* name, vscf_data_t* svc_cfg, const unsigned interval, const unsigned timeout) {
     dmn_assert(name); dmn_assert(svc_cfg);
+
+    // defaults
+    unsigned max_proc = 80;
+
 
     svcs = xrealloc(svcs, (num_svcs + 1) * sizeof(svc_t));
     svc_t* this_svc = &svcs[num_svcs++];
     this_svc->name = strdup(name);
     this_svc->timeout = timeout;
     this_svc->interval = interval;
+    SVC_OPT_UINT(svc_cfg, name, max_proc, 1LU, 65534LU);
+    this_svc->max_proc = max_proc;
 
     vscf_data_t* args_cfg = vscf_hash_get_data_byconstkey(svc_cfg, "cmd", true);
     if(!args_cfg)

--- a/plugins/extmon_comms.h
+++ b/plugins/extmon_comms.h
@@ -32,6 +32,7 @@ typedef struct {
     unsigned idx;
     unsigned timeout;
     unsigned interval;
+    unsigned max_proc;
     unsigned num_args;
     // all strings NUL-terminated
     char** args; // array-of-strings NULL-terminated

--- a/plugins/extmon_helper.c
+++ b/plugins/extmon_helper.c
@@ -242,9 +242,8 @@ static void mon_interval_cb(struct ev_loop* loop, ev_timer* w, int revents V_UNU
         //   is debugging via startfg they might want to see this crap anyways.
         execv(this_mon->cmd->args[0], this_mon->cmd->args);
         log_fatal("execv(%s, ...) failed: %s", this_mon->cmd->args[0], dmn_logf_strerror(errno));
-    } else { // parent
-        num_proc++;
     }
+    num_proc++;
 
     // restore previous signal mask from before fork in parent
     if(pthread_sigmask(SIG_SETMASK, &saved_mask, NULL))


### PR DESCRIPTION
Limits the number of concurrent checks that will be spawned.
If the limit is reached, excess checks are rescheduled for 0.1 seconds later.
This prevents a thundering herd, and after a few runs spreads the load out fairly evenly.

With over 150 servers and 500 service checks, this was a requirement for us.