### PR TITLE
More spelling fixes from Debian's lintian

### DIFF
--- a/docs/gdnsd-plugin-extmon.podin
+++ b/docs/gdnsd-plugin-extmon.podin
@@ -126,7 +126,7 @@ like anti-flap measures.
 
 =item B<max_proc>
 
-Interger, default 0 (unlimited).
+Integer, default 0 (unlimited).
 
 The maximum number of concurrent processes to spawn.
 

--- a/docs/gdnsd-plugin-geoip.podin
+++ b/docs/gdnsd-plugin-geoip.podin
@@ -148,7 +148,7 @@ are calculated without any knowledge of the resources that use them.  If a
 specific network or location maps to a list of datacenters which contains none
 of the defined datacenters for a given resource, the results of runtime
 queries for that resource from that location or network will be the empty set
-(no answer records at all).  This is virtually gauranteed to happen in "City
+(no answer records at all).  This is virtually guaranteed to happen in "City
 Auto Mode" if the number of undefined datacenters in a resource is greater
 than or equal to the map's C<auto_dc_limit>.
 

--- a/src/ztree.c
+++ b/src/ztree.c
@@ -406,7 +406,7 @@ static void _ztree_update(ztree_t* root, zone_t* z_old, zone_t* z_new, const boo
 
         if(z_new == new_list[0]) {
             if(old_head)
-                log_info("Zone %s: source %s with serial %u loaded as authoritative (supercedes extant source %s with serial %u)", logf_dname(z_new->dname), z_new->src, z_new->serial, old_head->src, old_head->serial);
+                log_info("Zone %s: source %s with serial %u loaded as authoritative (supersedes extant source %s with serial %u)", logf_dname(z_new->dname), z_new->src, z_new->serial, old_head->src, old_head->serial);
             else
                 log_info("Zone %s: source %s with serial %u loaded as authoritative", logf_dname(z_new->dname), z_new->src, z_new->serial);
         }

--- a/t/015zruntime/042multi.t
+++ b/t/015zruntime/042multi.t
@@ -15,7 +15,7 @@ _GDT->test_dns(
 # insert 3rd variant of example.com as EXAMPLE.COM
 _GDT->insert_altzone('example.com-3', '\069xample.com');
 _GDT->send_sigusr1_unless_inotify();
-_GDT->test_log_output('Zone example.com.: source rfc1035:\069xample.com with serial 3 loaded as authoritative (supercedes extant source rfc1035:example.com with serial 1)');
+_GDT->test_log_output('Zone example.com.: source rfc1035:\069xample.com with serial 3 loaded as authoritative (supersedes extant source rfc1035:example.com with serial 1)');
 _GDT->test_dns(
     qname => 'ns1.example.com', qtype => 'A',
     answer => 'ns1.example.com 86400 A 192.0.2.13',


### PR DESCRIPTION
* Interger   -> Integer
* gauranteed -> guaranteed
* supercedes -> supersedes