### PR TITLE
Remove syslog.target dependency from systemd unit

### DIFF
--- a/sysd/gdnsd.service.tmpl
+++ b/sysd/gdnsd.service.tmpl
@@ -2,7 +2,6 @@
 Description=gdnsd
 Documentation=man:gdnsd
 After=local-fs.target
-After=syslog.target
 After=network.target
 
 [Install]


### PR DESCRIPTION
According to https://wiki.freedesktop.org/www/Software/systemd/syslog/
this has been deprecated in favor of socket-activated syslog since
systemd v35+ which is... super old and unlikely to be found in the wild
right now.