### PR TITLE
fix compilation issue on ubuntu 22.04

### DIFF
--- a/libgdmaps/dclists.c
+++ b/libgdmaps/dclists.c
@@ -60,13 +60,6 @@
 //  used on true shutdown of the whole gdmap (only debug
 //  mode for the real plugin).
 
-struct dclists {
-    unsigned count; // count of unique result lists
-    unsigned old_count; // count from object we cloned from
-    uint8_t** list;    // strings of dc numbers
-    const dcinfo_t* info; // dclists_t doesn't own "info", just uses it for reference a lot
-};
-
 dclists_t* dclists_new(const dcinfo_t* info)
 {
     const unsigned num_dcs = dcinfo_get_count(info);

--- a/libgdmaps/dclists.h
+++ b/libgdmaps/dclists.h
@@ -28,6 +28,13 @@
 #include <inttypes.h>
 #include <stdbool.h>
 
+struct dclists {
+    unsigned count; // count of unique result lists
+    unsigned old_count; // count from object we cloned from
+    uint8_t** list;    // strings of dc numbers
+    const dcinfo_t* info; // dclists_t doesn't own "info", just uses it for reference a lot
+};
+
 typedef struct dclists dclists_t;
 
 typedef enum {


### PR DESCRIPTION
In file included from /usr/include/x86_64-linux-gnu/urcu/pointer.h:39,
                 from /usr/include/x86_64-linux-gnu/urcu/urcu-qsbr.h:40,
                 from /usr/include/x86_64-linux-gnu/urcu-qsbr.h:2,
                 from libgdmaps/gdmaps.c:52:
libgdmaps/gdmaps.c: In function 'gdmap_lookup':
libgdmaps/gdmaps.c:468:36: error: invalid use of undefined type 'struct dclists'
  468                                     rcu_dereference(gdmap->dclists),
                                          ^~~~~~~~~~~~~~~
make[3]: *** [Makefile:1212: libgdmaps/gdmaps.o] Error 1

The patch moves the struct dclists definition in dclists.h so the
compiler is happy with the typedef.

Fix #220.