### PR TITLE
Ignore SIGCHLD *after* daemon_fg_waiter()'s waitpid(2)

### DIFF
--- a/src/daemon.c
+++ b/src/daemon.c
@@ -190,6 +190,9 @@ static void do_daemonize(void)
 
 void gdnsd_init_daemon(const bool daemonize)
 {
+    if (daemonize)
+        do_daemonize();
+
     // Ignore SIGPIPE and SIGCHLD universally (we do have some forks, but in
     // all cases we don't care to zombie them and gather exit status).
     struct sigaction sa_ign;
@@ -200,9 +203,6 @@ void gdnsd_init_daemon(const bool daemonize)
         log_fatal("sigaction(SIGPIPE, SIG_IGN) failed: %s", logf_errno());
     if (sigaction(SIGCHLD, &sa_ign, NULL))
         log_fatal("sigaction(SIGCHLD, SIG_IGN) failed: %s", logf_errno());
-
-    if (daemonize)
-        do_daemonize();
 }
 
 void gdnsd_daemon_notify_ready(void)


### PR DESCRIPTION
On FreeBSD, at least, if we ignore SIGCHLD, then waitpid(2) will always return:

     [ECHILD]           No status from the terminated child process is
                        available because the calling process has asked the
                        system to discard such status by ignoring the signal
                        SIGCHLD or setting the flag SA_NOCLDWAIT for that
                        signal.

This causes 'gdnsd daemonize' to always abort:

waitpid(81417) during daemonization forks failed: No child processes

And then:

write() to daemonization status pipe failed: Broken pipe