### PR TITLE
tests: fix compatibility with Net::DNS 1.46

### DIFF
--- a/t/_GDT.pm
+++ b/t/_GDT.pm
@@ -1056,6 +1056,7 @@ sub query_server {
         );
         send($sock, $qpacket_raw, 0);
         if($expected) {
+            $query->encode;  # generate a random ID, required with Net::DNS >= 1.46
             $expected->header->id($query->header->id);
             my $res_raw;
             recv($sock, $res_raw, 4096, 0);
@@ -1075,6 +1076,7 @@ sub query_server {
         }
 
         if($expected) {
+            $query->encode;  # generate a random ID, required with Net::DNS >= 1.46
             $expected->header->id($query->header->id);
             $size = _GDT->compare_packets($res->send($query), $expected, $limit_v4, $limit_v6, $wrr_v4, $wrr_v6);
         }

--- a/t/_GDT.pm
+++ b/t/_GDT.pm
@@ -1075,6 +1075,9 @@ sub query_server {
             $res->$k($ro->{$k})
         }
 
+        # Net::DNS <= 1.45 (r1982) did this internally
+        $query->edns->size($ro->{udppacketsize}) if defined $ro->{udppacketsize};
+
         if($expected) {
             $query->encode;  # generate a random ID, required with Net::DNS >= 1.46
             $expected->header->id($query->header->id);


### PR DESCRIPTION
A newer version of Net::DNS, 1.46, broke the gdnsd test suite (again), in two different places this time. The two tiny commits should fix this issue.

Tested with versions as far back as 1.33. It seems 1.32 fails, but failed before even before these changes? (I am not interested in debugging such old versions myself.)

Thanks to @ncopa for the report and identifying one of the issues!

Fixes #246